### PR TITLE
Bugfix/prevent pagination parameters being passed as string

### DIFF
--- a/app/Http/Controllers/Core/V1/Search/PageController.php
+++ b/app/Http/Controllers/Core/V1/Search/PageController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace App\Http\Controllers\Core\V1\Search;
 

--- a/app/Http/Controllers/Core/V1/Search/PageController.php
+++ b/app/Http/Controllers/Core/V1/Search/PageController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace App\Http\Controllers\Core\V1\Search;
 

--- a/app/Http/Requests/Search/Pages/Request.php
+++ b/app/Http/Requests/Search/Pages/Request.php
@@ -25,6 +25,8 @@ class Request extends FormRequest
     {
         return [
             'query' => ['required', 'string', 'min:3', 'max:255'],
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'per_page' => ['sometimes', 'integer', 'min:1'],
         ];
     }
 }

--- a/app/Http/Requests/Search/Request.php
+++ b/app/Http/Requests/Search/Request.php
@@ -48,6 +48,8 @@ class Request extends FormRequest
                 'array',
             ],
             'eligibilities.*' => ['string'],
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'per_page' => ['sometimes', 'integer', 'min:1'],
         ];
     }
 }

--- a/tests/Feature/SearchPageTest.php
+++ b/tests/Feature/SearchPageTest.php
@@ -32,6 +32,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
     {
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'test',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -43,6 +45,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => $page->title,
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -57,6 +61,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => $page->content['introduction']['copy'][0],
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -79,6 +85,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'homeless',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -99,6 +107,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'temporary housing',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -120,6 +130,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Thisisatest',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -151,6 +163,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Thisisatest',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -161,6 +175,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
         // Fuzzy
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Thsiisatst',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -187,6 +203,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Anotherphrase',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -197,6 +215,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
         // Fuzzy
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Another phrase',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -212,6 +232,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Thisisatest',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);
@@ -242,6 +264,8 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
         $response = $this->json('POST', '/core/v1/search/pages', [
             'query' => 'Testing Page',
+            'page' => 1,
+            'per_page' => 20,
         ]);
 
         $response->assertStatus(Response::HTTP_OK);


### PR DESCRIPTION
### Summary

Enforced numeric type in validation for pagination parameters on search requests.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
