### PR TITLE
Fixed missing add tags when applying update request

### DIFF
--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Support\Str;
 use ScoutElastic\Searchable;
 
 class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTaxonomyRelationships
@@ -313,6 +314,23 @@ class Service extends Model implements AppliesUpdateRequests, Notifiable, HasTax
                     'order' => $offering['order'],
                 ]);
             }
+        }
+
+        // Update the tag records.
+        if (array_key_exists('tags', $data)) {
+            $tagIds = [];
+            foreach ($data['tags'] as $tagField) {
+                $tag = Tag::where('slug', Str::slug($tagField['slug']))->first();
+                if (null === $tag) {
+                    $tag = new Tag([
+                        'slug' => Str::slug($tagField['slug']),
+                        'label' => $tagField['label'],
+                    ]);
+                    $tag->save();
+                }
+                $tagIds[] = $tag->id;
+            }
+            $this->tags()->sync($tagIds);
         }
 
         // Update the gallery item records.


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/1535/add-ability-for-services-to-be-tagged-with-business-unit-labels

Added missing functionality to create and apply tags when the service is being updated via an update request

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
