### PR TITLE
Collection image marked as assigned when attached to collection

### DIFF
--- a/app/Http/Controllers/Core/V1/CollectionCategoryController.php
+++ b/app/Http/Controllers/Core/V1/CollectionCategoryController.php
@@ -141,6 +141,10 @@ class CollectionCategoryController extends Controller
                 ];
             }, $request->sideboxes ?? []);
 
+            if ($request->filled('image_file_id') && $request->image_file_id !== ($collection->meta['image_file_id']?? null)) {
+                File::findOrFail($request->image_file_id)->assigned();
+            }
+
             // Update the collection record.
             $collection->update([
                 'name' => $request->name,
@@ -155,10 +159,6 @@ class CollectionCategoryController extends Controller
                 'enabled' => $request->enabled,
                 'homepage' => $request->homepage,
             ]);
-
-            if ($request->filled('image_file_id') && $request->image_file_id !== $collection->meta['image_file_id']) {
-                File::findOrFail($request->image_file_id)->assigned();
-            }
 
             // Update or create all of the pivot records.
             $taxonomies = Taxonomy::whereIn('id', $request->category_taxonomies)->get();

--- a/tests/Feature/CollectionPersonasTest.php
+++ b/tests/Feature/CollectionPersonasTest.php
@@ -1732,6 +1732,11 @@ class CollectionPersonasTest extends TestCase
         $collectionArray = $this->getResponseContent($response)['data'];
         $content = $this->get("/core/v1/collections/personas/{$collectionArray['id']}/image.png")->content();
         $this->assertEquals($image, $content);
+
+        $this->assertDatabaseHas((new File)->getTable(), [
+            'id' => $this->getResponseContent($imageResponse, 'data.id'),
+            'meta' => null,
+        ]);
     }
 
     /*


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2026/collection-images-disappearing
The order of actions when updating a category collection with a new image meant that the image id was assigned to the collection prior to a test to see if the image id had changed, meaning that this test never passed resulting in the image never being set as assigned. this resulted in it being removed by a daily garbage collection script that deleted all un-assigned files.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
