### PR TITLE
Added staging environment warning banner to layout view

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -52,3 +52,11 @@ body {
 .govuk-button:focus {
   background-color: #263146 !important;
 }
+
+.warning {
+  background-color: #f9b34a;
+
+  .govuk-warning-text {
+    margin-bottom: 0;
+  }
+}

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -33,8 +33,10 @@
                     {{ config('app.name') }}
                 </a>
             </div>
-
         </div>
+        @if (config('app.env') === 'staging')
+            @include('partials.environment-warning')
+        @endif
     </header>
 
     <div class="govuk-width-container">

--- a/resources/views/partials/environment-warning.blade.php
+++ b/resources/views/partials/environment-warning.blade.php
@@ -1,0 +1,11 @@
+<div class="warning">
+    <div class="govuk-width-container">
+        <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon">!</span>
+                <strong class="govuk-warning-text__text">
+                    <span class="govuk-warning-text__assistive">Important</span>
+                    Please DO NOT make any changes to this site. This is a TEST environment used for demo purposes only. Any changes made here will not be reflected on the LIVE site viewed by the public. <a href="https://admin.suttoninformationhub.org.uk/">Click HERE</a> to access the LIVE environment.
+                </strong>
+            </div>
+    </div>
+</div>


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2064/create-global-staging-env-banner

- Add a banner that matches the admin environment warning banner for the views served from the api

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
