### PR TITLE
Removed single and double quotes from allowed password characters

### DIFF
--- a/app/Rules/Password.php
+++ b/app/Rules/Password.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Validation\Rule;
 
 class Password implements Rule
 {
-    const ALLOWED_SPECIAL_CHARACTERS = '!"#$%&\'()*+,-./:;<=>?@[]^_`{|}~';
+    const ALLOWED_SPECIAL_CHARACTERS = '!#$%&()*+,-./:;<=>?@[]^_`{|}~';
 
     /**
      * @var string|null


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/1472/update-the-admin-ui-password-guidance

- Updated the allowed password character string. Removed double and single quotes (" and ') as they were not being honoured

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
