### PR TITLE
Added sitemap controller and route

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -8,7 +8,6 @@ use App\Models\Page;
 use App\Models\Service;
 use DateTime;
 use DOMDocument;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 
 class SitemapController extends Controller

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Collection;
+use App\Models\Organisation;
+use App\Models\Page;
+use App\Models\Service;
+use DateTime;
+use DOMDocument;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
+
+class SitemapController extends Controller
+{
+    /**
+     * The DomDocument that holds the xml sitemap.
+     *
+     * @var DomDocument
+     */
+    protected $sitemap;
+
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function __invoke()
+    {
+        $sitemap = Cache::remember('sitemap', (60 * 60), function () {
+            $this->sitemap = new DOMDocument('1.0', 'UTF-8');
+            $urlset = $this->sitemap->createElementNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
+            $this->sitemap->appendChild($urlset);
+
+            $this->createStaticPageNodes();
+
+            $this->createServiceNodes();
+
+            $this->createOrganisationNodes();
+
+            $this->createCategoryNodes();
+
+            $this->createPersonaNodes();
+
+            $this->createPageNodes();
+
+            return $this->sitemap->saveXML();
+        });
+
+        return response($sitemap, 200);
+    }
+
+    /**
+     * Create the static page routes.
+     *
+     * @return array [DomElement]
+     */
+    public function createStaticPageNodes()
+    {
+        $pageSlugs = [
+            '',
+            'about',
+            'contact',
+            'get-involved',
+            'privacy-policy',
+            'terms-and-conditions',
+        ];
+
+        $pages = collect($pageSlugs)
+            ->map(function ($slug) {
+                return [
+                    'path' => $slug,
+                    'updated' => date(DateTime::W3C, strtotime('2 weeks ago')),
+                ];
+            })
+            ->all();
+
+        $this->addUrlNodes($pages);
+    }
+
+    /**
+     * Create the service routes.
+     *
+     * @return array [DomElement]
+     */
+    public function createServiceNodes()
+    {
+        $services = Service::where('status', '=', Service::STATUS_ACTIVE)
+            ->pluck('updated_at', 'slug')
+            ->map(function ($updatedAt, $slug) {
+                return [
+                    'path' => "services/$slug",
+                    'updated' => date(DateTime::W3C, strtotime($updatedAt)),
+                ];
+            })
+            ->all();
+
+        $this->addUrlNodes($services);
+    }
+
+    /**
+     * Create the organisation routes.
+     *
+     * @return array [DomElement]
+     */
+    public function createOrganisationNodes()
+    {
+        $organisations = Organisation::pluck('updated_at', 'slug')
+            ->map(function ($updatedAt, $slug) {
+                return [
+                    'path' => "organisations/$slug",
+                    'updated' => date(DateTime::W3C, strtotime($updatedAt)),
+                ];
+            })
+            ->all();
+
+        $this->addUrlNodes($organisations);
+    }
+
+    /**
+     * Create the Collection category routes.
+     *
+     * @return array [DomElement]
+     */
+    public function createCategoryNodes()
+    {
+        $categories = Collection::categories()
+            ->pluck('updated_at', 'id')
+            ->map(function ($updatedAt, $id) {
+                return [
+                    'path' => "results?category=$id",
+                    'updated' => date(DateTime::W3C, strtotime($updatedAt)),
+                ];
+            })
+            ->all();
+
+        $this->addUrlNodes($categories);
+    }
+
+    /**
+     * Create the Collection persona routes.
+     *
+     * @return array [DomElement]
+     */
+    public function createPersonaNodes()
+    {
+        $personas = Collection::personas()
+            ->pluck('updated_at', 'id')
+            ->map(function ($updatedAt, $id) {
+                return [
+                    'path' => "results?persona=$id",
+                    'updated' => date(DateTime::W3C, strtotime($updatedAt)),
+                ];
+            })
+            ->all();
+
+        $this->addUrlNodes($personas);
+    }
+
+    /**
+     * Create the information page routes.
+     *
+     * @return array [DomElement]
+     */
+    public function createPageNodes()
+    {
+        $pages = Page::where('enabled', '=', Page::ENABLED)
+            ->pluck('updated_at', 'id')
+            ->map(function ($updatedAt, $id) {
+                return [
+                    'path' => "$id",
+                    'updated' => date(DateTime::W3C, strtotime($updatedAt)),
+                ];
+            })
+            ->all();
+
+        $this->addUrlNodes($pages);
+    }
+
+    /**
+     * Create the static page routes.
+     *
+     * @param mixed $routes
+     * @param mixed|null $lastMod
+     * @param mixed $changeFreq
+     * @param mixed $priority
+     * @return array [DomElement]
+     */
+    public function addUrlNodes($routes, $lastMod = null, $changeFreq = 'monthly', $priority = '0.5')
+    {
+        $lastMod = $lastMod ?: date(DateTime::W3C);
+
+        $urlset = $this->sitemap->getElementsByTagNameNS('http://www.sitemaps.org/schemas/sitemap/0.9', 'urlset')->item(0);
+
+        foreach ($routes as $route) {
+            $url = $this->sitemap->createElement('url');
+            $url->appendChild($this->sitemap->createElement('loc', $this->frontendUrl($route['path'])));
+            $url->appendChild($this->sitemap->createElement('lastmod', $route['updated'] ?? $lastMod));
+            $url->appendChild($this->sitemap->createElement('changefreq', $changeFreq));
+            $url->appendChild($this->sitemap->createElement('priority', $priority));
+            $urlset->appendChild($url);
+        }
+    }
+
+    /**
+     * Create a frontend url for the given environment.
+     *
+     * @param string $path
+     * @return string
+     */
+    public function frontendUrl($path = '')
+    {
+        return str_replace('://api.', '://', url($path));
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Route;
 |
  */
 
-Route::namespace ('Auth')->group(function () {
+Route::namespace('Auth')->group(function () {
     // Authentication Routes.
     Route::get('login', 'LoginController@showLoginForm')->name('login');
     Route::post('login', 'LoginController@login');

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Facades\Route;
 | routes are loaded by the RouteServiceProvider within a group which
 | contains the "web" middleware group. Now create something great!
 |
-*/
+ */
 
-Route::namespace('Auth')->group(function () {
+Route::namespace ('Auth')->group(function () {
     // Authentication Routes.
     Route::get('login', 'LoginController@showLoginForm')->name('login');
     Route::post('login', 'LoginController@login');
@@ -35,3 +35,5 @@ Route::get('/docs', 'DocsController@index')
 
 Route::get('/docs/openapi.json', 'DocsController@show')
     ->name('docs.show');
+
+Route::get('/sitemap', 'SitemapController')->name('sitemap');

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Collection;
+use App\Models\Organisation;
+use App\Models\Page;
+use App\Models\Service;
+use DOMDocument;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SitemapTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!Storage::disk('local')->exists('test-data/sitemap.xsd')) {
+            Storage::disk('local')->put('test-data/sitemap.xsd', file_get_contents('http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'));
+        }
+    }
+
+    /**
+     * Create a frontend url for the given environment
+     *
+     * @param String $path
+     * @return String
+     **/
+    public function frontendUrl($path = '')
+    {
+        return str_replace('://api.', '://', url($path));
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapAsGuest200()
+    {
+        $response = $this->json('GET', '/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapReturnsXml200()
+    {
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $this->assertTrue($xml->loadXML($response->content()));
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapReturnsAValidSitemap200()
+    {
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $this->assertTrue($xml->schemaValidateSource(Storage::disk('local')->get('test-data/sitemap.xsd')));
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapIncludesStaticPages200()
+    {
+        $pages = [
+            'home' => false,
+            'about' => false,
+            'contact' => false,
+            'get-involved' => false,
+            'privacy-policy' => false,
+            'terms-and-conditions' => false,
+        ];
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $locTags = $xml->getElementsByTagName('loc');
+
+        foreach ($locTags as $tag) {
+            foreach ($pages as $page => &$status) {
+                $url = $page === 'home' ? $this->frontendUrl() : $this->frontendUrl($page);
+                if ($url === $tag->textContent) {
+                    $pages[$page] = true;
+                }
+            }
+        }
+
+        $this->assertNotContains(false, $pages);
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapIncludesServices200()
+    {
+        /** @var \App\Models\Service $service */
+        $service = factory(Service::class)->create();
+        $included = false;
+
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $locTags = $xml->getElementsByTagName('loc');
+
+        foreach ($locTags as $tag) {
+            if ($this->frontendUrl('services/' . $service->slug) === $tag->textContent) {
+                $included = true;
+            }
+        }
+
+        return $this->assertTrue($included);
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapIncludesOrganisations200()
+    {
+        /** @var \App\Models\Organisation $organisation */
+        $organisation = factory(Organisation::class)->create();
+        $included = false;
+
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $locTags = $xml->getElementsByTagName('loc');
+
+        foreach ($locTags as $tag) {
+            if ($this->frontendUrl('organisations/' . $organisation->slug) === $tag->textContent) {
+                $included = true;
+            }
+        }
+
+        return $this->assertTrue($included);
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapIncludesCategories200()
+    {
+        /** @var \App\Models\Collection $collection */
+        $collection = Collection::where('type', 'category')->latest()->first();
+        $included = false;
+
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $locTags = $xml->getElementsByTagName('loc');
+
+        foreach ($locTags as $tag) {
+            if ($this->frontendUrl('results?category=' . $collection->id) === $tag->textContent) {
+                $included = true;
+            }
+        }
+
+        return $this->assertTrue($included);
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapIncludesPersonas200()
+    {
+        /** @var \App\Models\Collection $collection */
+        $collection = Collection::where('type', 'persona')->latest()->first();
+        $included = false;
+
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $locTags = $xml->getElementsByTagName('loc');
+
+        foreach ($locTags as $tag) {
+            if ($this->frontendUrl('results?persona=' . $collection->id) === $tag->textContent) {
+                $included = true;
+            }
+        }
+
+        return $this->assertTrue($included);
+    }
+
+    /**
+     * @test
+     */
+    public function getSitemapIncludesPages200()
+    {
+        /** @var \App\Models\Page $page */
+        $page = factory(Page::class)->create();
+        $included = false;
+
+        $response = $this->get('/sitemap');
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $xml = new DOMDocument('1.0', 'UTF-8');
+
+        $xml->loadXML($response->content());
+
+        $locTags = $xml->getElementsByTagName('loc');
+
+        foreach ($locTags as $tag) {
+            if ($this->frontendUrl($page->id) === $tag->textContent) {
+                $included = true;
+            }
+        }
+
+        return $this->assertTrue($included);
+    }
+}


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2123/copy-xml-sitemap-across

- Copied sitemap tests, controller and route from Hounslow Connect
- Added pages to sitemap

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
