### PR TITLE
Added migration to convert page urls in pages, services and useful infos

### DIFF
--- a/database/migrations/2022_07_06_134340_find_page_id_urls_and_replace_with_page_slug_urls.php
+++ b/database/migrations/2022_07_06_134340_find_page_id_urls_and_replace_with_page_slug_urls.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\Page;
+use App\Models\Service;
+use App\Models\UsefulInfo;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class FindPageIdUrlsAndReplaceWithPageSlugUrls extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        $uuidRegex = '|suttoninformationhub\.org\.uk\/([0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})|i';
+        Page::chunk(50, function ($pages) use ($uuidRegex) {
+            foreach ($pages as $page) {
+                if (preg_match_all($uuidRegex, print_r($page->content, true), $matches)) {
+                    $content = $page->content;
+                    $matchingPages = DB::table((new Page())->getTable())
+                        ->whereIn('id', $matches[1])
+                        ->pluck('slug', 'id');
+                    foreach ($matchingPages as $id => $slug) {
+                        foreach ($content as $label => $details) {
+                            foreach ($details['copy'] as $i => $copy) {
+                                $content[$label]['copy'][$i] = str_replace("suttoninformationhub.org.uk/$id", "suttoninformationhub.org.uk/pages/$slug", $copy);
+                            }
+                        }
+                    }
+                    $page->content = $content;
+                    $page->save();
+                }
+            }
+        });
+
+        Service::chunk(50, function ($services) use ($uuidRegex) {
+            foreach ($services as $service) {
+                if (preg_match_all($uuidRegex, $service->description, $matches)) {
+                    $description = $service->description;
+                    $matchingServices = DB::table((new Service())->getTable())
+                        ->whereIn('id', $matches[1])
+                        ->pluck('slug', 'id');
+                    foreach ($matchingServices as $id => $slug) {
+                        $description = str_replace("suttoninformationhub.org.uk/$id", "suttoninformationhub.org.uk/pages/$slug", $description);
+                    }
+                    $service->description = $description;
+                    $service->save();
+                }
+            }
+        });
+
+        UsefulInfo::chunk(50, function ($usefulInfos) use ($uuidRegex) {
+            foreach ($usefulInfos as $usefulInfo) {
+                if (preg_match_all($uuidRegex, $usefulInfo->description, $matches)) {
+                    $description = $usefulInfo->description;
+                    $matchingUsefulInfos = DB::table((new usefulInfo())->getTable())
+                        ->whereIn('id', $matches[1])
+                        ->pluck('slug', 'id');
+                    foreach ($matchingUsefulInfos as $id => $slug) {
+                        $description = str_replace("suttoninformationhub.org.uk/$id", "suttoninformationhub.org.uk/pages/$slug", $description);
+                    }
+                    $usefulInfo->description = $description;
+                    $usefulInfo->save();
+                }
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2134/mass-find-replace-on-old-page-urls

- Added migration to replace page UUID urls with page slug urls in page content, service description and useful info description

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
