### PR TITLE
Update page request rules, make excerpt nullable

### DIFF
--- a/app/Http/Requests/Page/StoreRequest.php
+++ b/app/Http/Requests/Page/StoreRequest.php
@@ -42,7 +42,7 @@ class StoreRequest extends FormRequest
         return [
             'title' => ['required', 'string', 'min:1', 'max:255'],
             'slug' => ['string', 'min:1', 'max:255', new Slug()],
-            'excerpt' => ['string', 'min:1', 'max:150'],
+            'excerpt' => ['nullable', 'string', 'min:1', 'max:150'],
             'content' => ['required', 'array'],
             'content.introduction.copy' => ['required', 'array'],
             'content.introduction.copy.*' => ['required', 'string', 'min:1'],

--- a/app/Http/Requests/Page/UpdateRequest.php
+++ b/app/Http/Requests/Page/UpdateRequest.php
@@ -61,7 +61,7 @@ class UpdateRequest extends FormRequest
                     $this->page->slug
                 ),
             ],
-            'excerpt' => ['sometimes', 'string', 'min:1', 'max:150'],
+            'excerpt' => ['sometimes', 'nullable', 'string', 'min:1', 'max:150'],
             'content' => ['sometimes', 'array'],
             'content.introduction.*.copy' => ['sometimes', 'string', 'min:1'],
             'content.info_pages.*.title' => ['sometimes', 'string', 'min:1'],


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2170/excerpt-field-is-required-when-adding-a-new-page-it-should-be-optional

- Updated page request rules to make excerpt nullable on create and update

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
