### PR TITLE
Updated page to hold more complex structures in the content json

### DIFF
--- a/app/Http/Requests/Page/StoreRequest.php
+++ b/app/Http/Requests/Page/StoreRequest.php
@@ -8,6 +8,7 @@ use App\Rules\FileIsMimeType;
 use App\Rules\FileIsPendingAssignment;
 use App\Rules\InformationPageCannotHaveCollection;
 use App\Rules\LandingPageCannotHaveParent;
+use App\Rules\PageContent;
 use App\Rules\Slug;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -44,8 +45,7 @@ class StoreRequest extends FormRequest
             'slug' => ['string', 'min:1', 'max:255', new Slug()],
             'excerpt' => ['nullable', 'string', 'min:1', 'max:150'],
             'content' => ['required', 'array'],
-            'content.introduction.copy' => ['required', 'array'],
-            'content.introduction.copy.*' => ['required', 'string', 'min:1'],
+            'content.introduction.content' => ['required', 'array'],
             'content.info_pages.title' => [
                 'required_if:page_type,landing',
                 'string',
@@ -57,8 +57,8 @@ class StoreRequest extends FormRequest
                 'min:1',
             ],
             'content.*.title' => ['sometimes', 'string'],
-            'content.*.copy' => ['sometimes', 'array'],
-            'content.*.copy.*' => ['sometimes', 'string'],
+            'content.*.content' => ['sometimes', 'array'],
+            'content.*.content.*' => [new PageContent()],
             'order' => [
                 'integer',
                 'min:0',

--- a/app/Http/Requests/Page/UpdateRequest.php
+++ b/app/Http/Requests/Page/UpdateRequest.php
@@ -10,6 +10,7 @@ use App\Rules\FileIsMimeType;
 use App\Rules\FileIsPendingAssignment;
 use App\Rules\InformationPageCannotHaveCollection;
 use App\Rules\LandingPageCannotHaveParent;
+use App\Rules\PageContent;
 use App\Rules\Slug;
 use App\Rules\UserHasRole;
 use Illuminate\Foundation\Http\FormRequest;
@@ -63,11 +64,11 @@ class UpdateRequest extends FormRequest
             ],
             'excerpt' => ['sometimes', 'nullable', 'string', 'min:1', 'max:150'],
             'content' => ['sometimes', 'array'],
-            'content.introduction.*.copy' => ['sometimes', 'string', 'min:1'],
             'content.info_pages.*.title' => ['sometimes', 'string', 'min:1'],
             'content.collections.*.title' => ['sometimes', 'string', 'min:1'],
-            'content.*.*.title' => ['sometimes', 'string'],
-            'content.*.*.copy' => ['sometimes', 'string'],
+            'content.*.title' => ['sometimes', 'string'],
+            'content.*.content' => ['sometimes', 'array'],
+            'content.*.content.*' => [new PageContent()],
             'order' => [
                 'sometimes',
                 'integer',

--- a/app/Models/Mutators/PageMutators.php
+++ b/app/Models/Mutators/PageMutators.php
@@ -33,8 +33,12 @@ trait PageMutators
         // Sanitize the JSON content field
 
         foreach ($value as $section => &$sectionContent) {
-            if ($sectionContent['copy']) {
-                array_walk($sectionContent['copy'], 'sanitize_markdown');
+            if ($sectionContent['content']) {
+                foreach ($sectionContent['content'] as &$content) {
+                    if ($content['type'] === 'copy') {
+                        $content['value'] = sanitize_markdown($content['value']);
+                    }
+                }
             }
         }
 

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -89,25 +89,25 @@ class Page extends Model
                     'introduction' => [
                         'properties' => [
                             'title' => ['type' => 'text'],
-                            'copy' => ['type' => 'text'],
+                            'content' => ['type' => 'text'],
                         ],
                     ],
                     'about' => [
                         'properties' => [
                             'title' => ['type' => 'text'],
-                            'copy' => ['type' => 'text'],
+                            'content' => ['type' => 'text'],
                         ],
                     ],
                     'info_pages' => [
                         'properties' => [
                             'title' => ['type' => 'text'],
-                            'copy' => ['type' => 'text'],
+                            'content' => ['type' => 'text'],
                         ],
                     ],
                     'collections' => [
                         'properties' => [
                             'title' => ['type' => 'text'],
-                            'copy' => ['type' => 'text'],
+                            'content' => ['type' => 'text'],
                         ],
                     ],
                 ],
@@ -124,11 +124,33 @@ class Page extends Model
      */
     public function toSearchableArray()
     {
+        $contentSections = [];
+        foreach ($this->content as $sectionLabel => $sectionContent) {
+            $content = [];
+            foreach ($sectionContent['content'] as $i => $contentBlock) {
+                switch ($contentBlock['type']) {
+                    case 'copy':
+                        $content[] = $contentBlock['value'];
+                        break;
+                    case 'cta':
+                        $content[] = $contentBlock['title'] . ' ' . $contentBlock['description'];
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            $contentSections[$sectionLabel] = [
+                'title' => $sectionContent['title'] ?? '',
+                'content' => implode("\n", $content),
+            ];
+        }
+
         return [
             'id' => $this->id,
             'enabled' => $this->enabled,
             'title' => $this->title,
-            'content' => $this->content,
+            'content' => $contentSections,
             'collection_categories' => $this->collections()->where('type', Collection::TYPE_CATEGORY)->pluck('name')->all(),
             'collection_personas' => $this->collections()->where('type', Collection::TYPE_PERSONA)->pluck('name')->all(),
         ];

--- a/app/Rules/PageContent.php
+++ b/app/Rules/PageContent.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class PageContent implements Rule
+{
+    /**
+     * The error message to return.
+     *
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        // Immediately fail if the value is not an array.
+        if (!is_array($value)) {
+            return false;
+        }
+
+        if ($value['type'] === 'copy') {
+            if (!isset($value['value']) || !is_string($value['value']) || mb_strlen($value['value']) === 0) {
+                $this->message = 'Introduction copy is required';
+
+                return false;
+            }
+        }
+        if ($value['type'] === 'cta') {
+            if ((!isset($value['title']) || !is_string($value['title']) || mb_strlen($value['title']) === 0)) {
+                $this->message = 'Call to action title is required';
+
+                return false;
+            }
+            if (!isset($value['description']) || !is_string($value['description']) || mb_strlen($value['description']) === 0) {
+                $this->message = 'Call to action description is required';
+
+                return false;
+            }
+            if ((!empty($value['url']) && empty($value['buttonText'])) || (empty($value['url']) && !empty($value['buttonText']))) {
+                $this->message = 'Call to action with a link requires both the URL and the button text';
+
+                return false;
+            }
+            if (!empty($value['url']) && filter_var($value['url'], FILTER_VALIDATE_URL) === false) {
+                $this->message = 'Call to action link must be a valid URL';
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return $this->message;
+    }
+}

--- a/app/Search/ElasticsearchPageSearch.php
+++ b/app/Search/ElasticsearchPageSearch.php
@@ -59,13 +59,13 @@ class ElasticsearchPageSearch implements PageSearch
 
         $should[] = $this->match('title', $term, 3);
         $should[] = $this->match('content.introduction.title', $term, 2);
-        $should[] = $this->match('content.introduction.copy', $term);
+        $should[] = $this->match('content.introduction.content', $term);
         $should[] = $this->match('content.about.title', $term, 2);
-        $should[] = $this->match('content.about.copy', $term);
+        $should[] = $this->match('content.about.content', $term);
         $should[] = $this->match('content.info_pages.title', $term, 2);
-        $should[] = $this->match('content.info_pages.copy', $term);
+        $should[] = $this->match('content.info_pages.content', $term);
         $should[] = $this->match('content.collections.title', $term, 2);
-        $should[] = $this->match('content.collections.copy', $term);
+        $should[] = $this->match('content.collections.content', $term);
         $should[] = $this->match('collection_categories', $term);
         $should[] = $this->match('collection_personas', $term);
 

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -16,8 +16,11 @@ $factory->define(Page::class, function (Faker $faker) {
         'slug' => Str::slug($title),
         'content' => [
             'introduction' => [
-                'copy' => [
-                    $this->faker->realText(),
+                'content' => [
+                    [
+                        'type' => 'copy',
+                        'value' => $this->faker->realText(),
+                    ],
                 ],
             ],
         ],
@@ -43,26 +46,55 @@ $factory->state(Page::class, 'landingPage', [
     'page_type' => Page::PAGE_TYPE_LANDING,
     'content' => [
         'introduction' => [
-            'copy' => [
-                $this->faker->realText(),
+            'content' => [
+                [
+                    'type' => 'copy',
+                    'value' => $this->faker->realText(),
+                ],
+                [
+                    'type' => 'cta',
+                    'title' => $this->faker->sentence,
+                    'description' => $this->faker->realText(),
+                    'url' => $this->faker->url(),
+                    'buttonText' => $this->faker->words(3, true),
+                ],
             ],
         ],
         'about' => [
-            'copy' => [
-                $this->faker->realText(),
-                $this->faker->realText(),
+            'content' => [
+                [
+                    'type' => 'copy',
+                    'value' => $this->faker->realText(),
+                ],
+                [
+                    'type' => 'cta',
+                    'title' => $this->faker->sentence,
+                    'description' => $this->faker->realText(),
+                    'url' => $this->faker->url(),
+                    'buttonText' => $this->faker->words(3, true),
+                ],
+                [
+                    'type' => 'copy',
+                    'value' => $this->faker->realText(),
+                ],
             ],
         ],
         'info-pages' => [
             'title' => $this->faker->sentence(),
-            'copy' => [
-                $this->faker->realText(),
+            'content' => [
+                [
+                    'type' => 'copy',
+                    'value' => $this->faker->realText(),
+                ],
             ],
         ],
         'collections' => [
             'title' => $this->faker->sentence(),
-            'copy' => [
-                $this->faker->realText(),
+            'content' => [
+                [
+                    'type' => 'copy',
+                    'value' => $this->faker->realText(),
+                ],
             ],
         ],
     ],

--- a/database/migrations/2022_07_08_095358_update_pages_content_json_structure_to_hold_mixed_content_types.php
+++ b/database/migrations/2022_07_08_095358_update_pages_content_json_structure_to_hold_mixed_content_types.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Page;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdatePagesContentJsonStructureToHoldMixedContentTypes extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            Page::chunk(50, function ($pages) {
+                foreach ($pages as $page) {
+                    $content = $page->content;
+
+                    foreach ($content as $key => $value) {
+                        $copyArr = $value['copy'];
+                        $value['content'] = [];
+                        foreach ($copyArr as $copy) {
+                            $value['content'][] = [
+                                'type' => 'copy',
+                                'value' => $copy,
+                            ];
+                        }
+                        unset($value['copy']);
+                        $content[$key] = $value;
+                    }
+
+                    $page->content = $content;
+                    $page->save();
+                }
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -1072,8 +1072,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1105,8 +1108,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1158,8 +1164,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1188,81 +1197,105 @@ class PagesTest extends TestCase
 
         Passport::actingAs($user);
 
+        // Missing content
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Missing title
         $this->json('POST', '/core/v1/pages', [
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Empty title and content
         $this->json('POST', '/core/v1/pages', [
             'title' => '',
             'content' => '',
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Content not an array
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->realText(),
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Content an empty array
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [],
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Invalid structure for 'copy' content type
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => str_pad($this->faker->paragraph(2), 151, 'words '),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'copy' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Invalid parent id
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
             'parent_id' => 1,
         ])->assertStatus(Response::HTTP_NOT_FOUND);
 
+        // Unknown parent id
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
             'parent_id' => $this->faker->uuid(),
         ])->assertStatus(Response::HTTP_NOT_FOUND);
 
+        // Invalid content stucture for landing page
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1271,13 +1304,17 @@ class PagesTest extends TestCase
 
         $parentPage = factory(Page::class)->states('withChildren')->create();
 
+        // Invalid order
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1285,13 +1322,17 @@ class PagesTest extends TestCase
             'order' => $parentPage->children->count() + 1,
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Invalid order
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1299,13 +1340,17 @@ class PagesTest extends TestCase
             'order' => -1,
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
+        // Landing page cannot have parent
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1313,9 +1358,7 @@ class PagesTest extends TestCase
             'page_type' => 'landing',
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        /**
-         * Assigned Images not allowed
-         */
+        // Assigned Images not allowed
         $image = factory(File::class)->create([
             'filename' => Str::random() . '.png',
             'mime_type' => 'image/png',
@@ -1326,8 +1369,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1357,8 +1403,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1417,8 +1466,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1454,8 +1506,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1514,26 +1569,41 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
                 'about' => [
-                    'copy' => [
-                        $this->faker->realText(),
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
                 'info_pages' => [
                     'title' => $this->faker->sentence(),
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
                 'collections' => [
                     'title' => $this->faker->sentence(),
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1596,8 +1666,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1639,8 +1712,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1690,8 +1766,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1759,8 +1838,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1828,8 +1910,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1890,8 +1975,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1924,26 +2012,41 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
                 'about' => [
-                    'copy' => [
-                        $this->faker->realText(),
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
                 'info_pages' => [
                     'title' => $this->faker->sentence(),
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
                 'collections' => [
                     'title' => $this->faker->sentence(),
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -1992,6 +2095,257 @@ class PagesTest extends TestCase
     /**
      * @test
      */
+    public function createInformationPageWithCallToAction422()
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = factory(User::class)->create();
+        $user->makeGlobalAdmin();
+
+        Passport::actingAs($user);
+
+        $parentPage = factory(Page::class)->create();
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => '',
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+            ],
+            'parent_id' => $parentPage->id,
+            'page_type' => 'information',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => null,
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+            ],
+            'parent_id' => $parentPage->id,
+            'page_type' => 'information',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => null,
+                        ],
+                    ],
+                ],
+            ],
+            'parent_id' => $parentPage->id,
+            'page_type' => 'information',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => 'foo',
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+            ],
+            'parent_id' => $parentPage->id,
+            'page_type' => 'information',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * @test
+     */
+    public function createInformationPageWithCallToAction201()
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = factory(User::class)->create();
+        $user->makeGlobalAdmin();
+
+        Passport::actingAs($user);
+
+        $parentPage = factory(Page::class)->create();
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+            ],
+            'parent_id' => $parentPage->id,
+            'page_type' => 'information',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function createLandingPageWithCallToActions201()
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = factory(User::class)->create();
+        $user->makeGlobalAdmin();
+
+        Passport::actingAs($user);
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+                'about' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                    ],
+                ],
+                'info_pages' => [
+                    'title' => $this->faker->sentence(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+                'collections' => [
+                    'title' => $this->faker->sentence(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                    ],
+                ],
+            ],
+            'page_type' => 'landing',
+        ];
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
     public function createPageWithSameTitleAsExistingPageIncrementsSlugAsAdmin201()
     {
         /**
@@ -2016,8 +2370,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],
@@ -2072,8 +2429,11 @@ class PagesTest extends TestCase
             'excerpt' => substr($this->faker->paragraph(2), 0, 149),
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        $this->faker->realText(),
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
                     ],
                 ],
             ],

--- a/tests/Feature/SearchPageTest.php
+++ b/tests/Feature/SearchPageTest.php
@@ -57,10 +57,10 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
 
     public function test_query_matches_page_content()
     {
-        $page = factory(Page::class)->create();
+        $page = factory(Page::class)->states('landingPage')->create();
 
         $response = $this->json('POST', '/core/v1/search/pages', [
-            'query' => $page->content['introduction']['copy'][0],
+            'query' => $page->content['introduction']['content'][0]['value'],
             'page' => 1,
             'per_page' => 20,
         ]);
@@ -69,6 +69,49 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
         $response->assertJsonFragment([
             'id' => $page->id,
         ]);
+
+        $page = factory(Page::class)->states('landingPage')->create([
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                        [
+                            'type' => 'cta',
+                            'title' => $this->faker->sentence,
+                            'description' => $this->faker->realText(),
+                            'url' => $this->faker->url(),
+                            'buttonText' => $this->faker->words(3, true),
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->json('POST', '/core/v1/search/pages', [
+            'query' => $page->content['introduction']['content'][1]['title'],
+            'page' => 1,
+            'per_page' => 20,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'id' => $page->id,
+        ]);
+
+        $response = $this->json('POST', '/core/v1/search/pages', [
+            'query' => $page->content['introduction']['content'][1]['description'],
+            'page' => 1,
+            'per_page' => 20,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment([
+            'id' => $page->id,
+        ]);
+
     }
 
     public function test_query_matches_single_word_from_page_content()
@@ -76,8 +119,11 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
         $page = factory(Page::class)->create([
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        'This is a page that helps to homeless find temporary housing.',
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => 'This is a page that helps to homeless find temporary housing.',
+                        ],
                     ],
                 ],
             ],
@@ -98,8 +144,11 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
         $page = factory(Page::class)->create([
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        'This is a page that helps to homeless find temporary housing.',
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => 'This is a page that helps to homeless find temporary housing.',
+                        ],
                     ],
                 ],
             ],
@@ -121,8 +170,11 @@ class SearchPageTest extends TestCase implements UsesElasticsearch
         $page2 = factory(Page::class)->create([
             'content' => [
                 'introduction' => [
-                    'copy' => [
-                        'Thisisatest',
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => 'Thisisatest',
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2138/update-page-structure-to-allow-content-blocks

- Update page request rules to work with new content block structure
- Create migration to convert all existing pages to new content block structure
- Update search facility to work with new content structure
- Update tests to work with new content structure

### Development checklist

- [x] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [x] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
