### PR TITLE
Sutton sc 2179 make content optional for information pages

### DIFF
--- a/app/Http/Controllers/Core/V1/PageController.php
+++ b/app/Http/Controllers/Core/V1/PageController.php
@@ -77,7 +77,7 @@ class PageController extends Controller
                     'title' => $request->input('title'),
                     'slug' => $this->uniqueSlug($request->input('slug', Str::slug($request->input('title')))),
                     'excerpt' => $request->input('excerpt'),
-                    'content' => $request->input('content'),
+                    'content' => $request->input('content', []),
                     'page_type' => $request->input('page_type', Page::PAGE_TYPE_INFORMATION),
                 ],
                 $parent

--- a/app/Http/Requests/Page/StoreRequest.php
+++ b/app/Http/Requests/Page/StoreRequest.php
@@ -43,9 +43,9 @@ class StoreRequest extends FormRequest
         return [
             'title' => ['required', 'string', 'min:1', 'max:255'],
             'slug' => ['string', 'min:1', 'max:255', new Slug()],
-            'excerpt' => ['nullable', 'string', 'min:1', 'max:150'],
-            'content' => ['required', 'array'],
-            'content.introduction.content' => ['required', 'array'],
+            'excerpt' => ['sometimes', 'nullable', 'string', 'min:1', 'max:150'],
+            'content' => ['required_if:page_type,landing', 'array'],
+            'content.introduction.content' => ['required_if:page_type,landing', 'array'],
             'content.info_pages.title' => [
                 'required_if:page_type,landing',
                 'string',

--- a/app/Http/Requests/Page/StoreRequest.php
+++ b/app/Http/Requests/Page/StoreRequest.php
@@ -58,7 +58,7 @@ class StoreRequest extends FormRequest
             ],
             'content.*.title' => ['sometimes', 'string'],
             'content.*.content' => ['sometimes', 'array'],
-            'content.*.content.*' => [new PageContent()],
+            'content.*.content.*' => [new PageContent($this->page_type)],
             'order' => [
                 'integer',
                 'min:0',

--- a/app/Http/Requests/Page/UpdateRequest.php
+++ b/app/Http/Requests/Page/UpdateRequest.php
@@ -68,7 +68,7 @@ class UpdateRequest extends FormRequest
             'content.collections.*.title' => ['sometimes', 'string', 'min:1'],
             'content.*.title' => ['sometimes', 'string'],
             'content.*.content' => ['sometimes', 'array'],
-            'content.*.content.*' => [new PageContent()],
+            'content.*.content.*' => [new PageContent($this->page->page_type)],
             'order' => [
                 'sometimes',
                 'integer',

--- a/app/Models/Mutators/PageMutators.php
+++ b/app/Models/Mutators/PageMutators.php
@@ -36,7 +36,7 @@ trait PageMutators
             if (!empty($sectionContent['content'])) {
                 foreach ($sectionContent['content'] as &$content) {
                     if ($content['type'] === 'copy') {
-                        $content['value'] = sanitize_markdown($content['value']);
+                        $content['value'] = sanitize_markdown($content['value'] ?? '');
                     }
                 }
             }

--- a/app/Models/Mutators/PageMutators.php
+++ b/app/Models/Mutators/PageMutators.php
@@ -33,7 +33,7 @@ trait PageMutators
         // Sanitize the JSON content field
 
         foreach ($value as $section => &$sectionContent) {
-            if ($sectionContent['content']) {
+            if (!empty($sectionContent['content'])) {
                 foreach ($sectionContent['content'] as &$content) {
                     if ($content['type'] === 'copy') {
                         $content['value'] = sanitize_markdown($content['value']);

--- a/app/Rules/PageContent.php
+++ b/app/Rules/PageContent.php
@@ -14,6 +14,21 @@ class PageContent implements Rule
     protected $message;
 
     /**
+     * The page type: landing, information, etc.
+     *
+     * @var string
+     */
+    protected $pageType;
+
+    /**
+     * @param mixed $pageType
+     */
+    public function __construct($pageType = 'information')
+    {
+        $this->pageType = $pageType;
+    }
+
+    /**
      * Determine if the validation rule passes.
      *
      * @param string $attribute
@@ -28,19 +43,24 @@ class PageContent implements Rule
         }
 
         if ($value['type'] === 'copy') {
-            if (!isset($value['value']) || !is_string($value['value']) || mb_strlen($value['value']) === 0) {
-                $this->message = 'Invalid format for copy content block';
+            if (!array_key_exists('value', $value)) {
+                $this->message = 'Invalid format for content';
+
+                return false;
+            }
+            if (($this->pageType === 'landing' && mb_strpos($attribute, 'introduction') && empty($value['value']))) {
+                $this->message = 'Page content is required for introduction';
 
                 return false;
             }
         }
         if ($value['type'] === 'cta') {
-            if ((!isset($value['title']) || !is_string($value['title']) || mb_strlen($value['title']) === 0)) {
+            if (empty($value['title']) || !is_string($value['title'])) {
                 $this->message = 'Call to action title is required';
 
                 return false;
             }
-            if (!isset($value['description']) || !is_string($value['description']) || mb_strlen($value['description']) === 0) {
+            if (empty($value['description']) || !is_string($value['description'])) {
                 $this->message = 'Call to action description is required';
 
                 return false;

--- a/app/Rules/PageContent.php
+++ b/app/Rules/PageContent.php
@@ -29,7 +29,7 @@ class PageContent implements Rule
 
         if ($value['type'] === 'copy') {
             if (!isset($value['value']) || !is_string($value['value']) || mb_strlen($value['value']) === 0) {
-                $this->message = 'Introduction copy is required';
+                $this->message = 'Invalid format for copy content block';
 
                 return false;
             }

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -1145,6 +1145,74 @@ class PagesTest extends TestCase
     /**
      * @test
      */
+    public function createPageWithMinimalDataAsAdmin201()
+    {
+        /**
+         * @var \App\Models\User $user
+         */
+        $user = factory(User::class)->create();
+        $user->makeGlobalAdmin();
+
+        Passport::actingAs($user);
+
+        $parentPage = factory(Page::class)->create();
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'parent_id' => $parentPage->id,
+        ];
+
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+
+        $response->assertJsonResource([
+            'id',
+            'title',
+            'excerpt',
+            'content',
+            'order',
+            'enabled',
+            'page_type',
+            'image',
+            'landing_page',
+            'parent',
+            'children',
+            'collection_categories',
+            'collection_personas',
+            'created_at',
+            'updated_at',
+        ]);
+
+        $data = [
+            'title' => $this->faker->sentence(),
+            'content' => [
+                'introduction' => [
+                    'content' => [
+                        [
+                            'type' => 'copy',
+                            'value' => $this->faker->realText(),
+                        ],
+                    ],
+                ],
+                'info_pages' => [
+                    'title' => $this->faker->sentence(),
+                ],
+                'collections' => [
+                    'title' => $this->faker->sentence(),
+                ],
+            ],
+            'page_type' => 'landing',
+        ];
+
+        $response = $this->json('POST', '/core/v1/pages', $data);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
     public function auditCreatedOnCreate()
     {
         $this->fakeEvents();
@@ -1197,11 +1265,6 @@ class PagesTest extends TestCase
 
         Passport::actingAs($user);
 
-        // Missing content
-        $this->json('POST', '/core/v1/pages', [
-            'title' => $this->faker->sentence(),
-        ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
-
         // Missing title
         $this->json('POST', '/core/v1/pages', [
             'content' => [
@@ -1226,13 +1289,6 @@ class PagesTest extends TestCase
         $this->json('POST', '/core/v1/pages', [
             'title' => $this->faker->sentence(),
             'content' => $this->faker->realText(),
-        ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
-
-        // Content an empty array
-        $this->json('POST', '/core/v1/pages', [
-            'title' => $this->faker->sentence(),
-            'excerpt' => substr($this->faker->paragraph(2), 0, 149),
-            'content' => [],
         ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         // Invalid structure for 'copy' content type


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2179/make-content-optional-for-information-pages

- Allow information pages to have an empty content value
- Continue to require introduction content for landing pages

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
