### PR TITLE
Updated sitemap to use new pages url with slug

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -162,10 +162,10 @@ class SitemapController extends Controller
     public function createPageNodes()
     {
         $pages = Page::where('enabled', '=', Page::ENABLED)
-            ->pluck('updated_at', 'id')
-            ->map(function ($updatedAt, $id) {
+            ->pluck('updated_at', 'slug')
+            ->map(function ($updatedAt, $slug) {
                 return [
-                    'path' => "$id",
+                    'path' => "pages/$slug",
                     'updated' => date(DateTime::W3C, strtotime($updatedAt)),
                 ];
             })

--- a/tests/Feature/SitemapTest.php
+++ b/tests/Feature/SitemapTest.php
@@ -240,7 +240,7 @@ class SitemapTest extends TestCase
         $locTags = $xml->getElementsByTagName('loc');
 
         foreach ($locTags as $tag) {
-            if ($this->frontendUrl($page->id) === $tag->textContent) {
+            if ($this->frontendUrl('pages/' . $page->slug) === $tag->textContent) {
                 $included = true;
             }
         }


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2209/update-the-sitemap-xml-routes-for-pages-to-use-slugs-instead-of-uuids

- Altered sitemap.xml page URLs to match new format with slug

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
