### PR TITLE
Hotfix/1.7.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,12 +62,12 @@ services:
     command: mysqld --general-log=1 --general-log-file=/var/log/mysql/general-log.log
 
   redis:
-    image: grokzen/redis-cluster:5.0.5
+    image: grokzen/redis-cluster:6.0.16
     volumes:
       - redis-data:/data
 
   redis-testing:
-    image: grokzen/redis-cluster:5.0.5
+    image: grokzen/redis-cluster:6.0.16
 
   elasticsearch:
     image: elasticsearch:7.9.3


### PR DESCRIPTION
### Summary

The Redis image Github repo (https://github.com/Grokzen/docker-redis-cluster) has dropped support for version 5.5 which is used by the Docker testing environment (https://github.com/Grokzen/docker-redis-cluster/commit/d597529abb5d9e8b02721c7a2a690f7100fd67e8)

The Redis image tag has been updated from version 5.0.5 to 6.0.16

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
