### PR TITLE
Updated service offerings relationship to honour order

### DIFF
--- a/app/Models/Relationships/ServiceRelationships.php
+++ b/app/Models/Relationships/ServiceRelationships.php
@@ -84,7 +84,7 @@ trait ServiceRelationships
      */
     public function offerings()
     {
-        return $this->hasMany(Offering::class);
+        return $this->hasMany(Offering::class)->orderBy('order', 'asc');
     }
 
     /**

--- a/tests/Feature/ServicesTest.php
+++ b/tests/Feature/ServicesTest.php
@@ -1865,6 +1865,46 @@ class ServicesTest extends TestCase
         ]);
     }
 
+    public function test_offerings_are_returned_in_order()
+    {
+        $service = factory(Service::class)->create();
+        $taxonomy = factory(Taxonomy::class)->create();
+        $service->usefulInfos()->create([
+            'title' => 'Did You Know?',
+            'description' => 'This is a test description',
+            'order' => 1,
+        ]);
+        $service->offerings()->createMany([
+            [
+                'offering' => 'First club',
+                'order' => 1,
+            ],
+            [
+                'offering' => 'Second club',
+                'order' => 2,
+            ],
+            [
+                'offering' => 'Third club',
+                'order' => 3,
+            ],
+        ]);
+        $service->socialMedias()->create([
+            'type' => SocialMedia::TYPE_INSTAGRAM,
+            'url' => 'https://www.instagram.com/ayupdigital/',
+        ]);
+        $service->serviceTaxonomies()->create([
+            'taxonomy_id' => $taxonomy->id,
+        ]);
+
+        $response = $this->json('GET', "/core/v1/services/{$service->slug}");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $offerings = $response->json('data.offerings');
+        $this->assertEquals(1, $offerings[0]['order']);
+        $this->assertEquals(2, $offerings[1]['order']);
+        $this->assertEquals(3, $offerings[2]['order']);
+    }
+
     public function test_audit_created_when_viewed()
     {
         $this->fakeEvents();


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2567/service-offerings-ordering-bug

- Service offerings were being returned in no particular order
- Updated `Service::offerings` relationship to honour the `Offering::order` property

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
