### PR TITLE
Fixed the php-buildpack version to 4.4.68

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 defaults: &defaults
-  buildpack: php_buildpack
+  buildpack: https://github.com/cloudfoundry/php-buildpack.git#v4.4.68
   services:
   - name: hys-db
   - name: sutton-redis


### PR DESCRIPTION
### Summary

- GovPaaS have archived php-buildpack v4.4.68 which is the last php-buildpack to use PHP7.4. This made deployments fail as the composer requirement for PHP7.4 could not be satisfied
- Updated `manifest.yml` to require the specific php-buildpack v4.4.68 via it's GitHub URL so binding the depoment only to that buildpack. This allows the deploy to use archived buildpacks.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
