### PR TITLE
Updated source of sqs region in queue config

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -55,7 +55,7 @@ return [
             'secret' => env('SQS_SECRET_ACCESS_KEY', 'your-secret-key'),
             'prefix' => env('SQS_PREFIX', 'https://sqs.eu-west-1.amazonaws.com/your-account-id'),
             'queue' => env('SQS_QUEUE', 'default'),
-            'region' => env('SQS_DEFAULT_REGION', 'eu-west-1'),
+            'region' => env('AWS_DEFAULT_REGION', 'eu-west-1'),
         ],
 
         'redis' => [


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2680/create-aws-api-architecture

- Could not connect to SQS (Message: SignatureDoesNotMatch (client): Credential should be scoped to a valid region.)
- Region mismatch due to differences in .env. Changed env var to AWS_DEFAULT_REGION

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
