### PR TITLE
Changed env vars to get aws access credentials from

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -51,8 +51,8 @@ return [
 
         'sqs' => [
             'driver' => 'sqs',
-            'key' => env('SQS_ACCESS_KEY_ID', 'your-public-key'),
-            'secret' => env('SQS_SECRET_ACCESS_KEY', 'your-secret-key'),
+            'key' => env('AWS_ACCESS_KEY_ID', 'your-public-key'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY', 'your-secret-key'),
             'prefix' => env('SQS_PREFIX', 'https://sqs.eu-west-1.amazonaws.com/your-account-id'),
             'queue' => env('SQS_QUEUE', 'default'),
             'region' => env('AWS_DEFAULT_REGION', 'eu-west-1'),


### PR DESCRIPTION
### Summary

https://app.shortcut.com/helpyourselfsutton/story/2683/deploy-api-to-aws

- Changed queue config for sqs to use `AWS_ACCESS_KEY_ID` instead of `SQS_ACCESS_KEY_ID`
- Changed queue config for sqs to use `AWS_SECRET_ACCESS_KEY` instead of `SQS_SECRET_ACCESS_KEY`

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
