### PR TITLE
removed es linked role id output

### DIFF
--- a/aws/cloudformation.py
+++ b/aws/cloudformation.py
@@ -30,12 +30,12 @@ from resources import create_load_balancer_security_group_resource, create_api_s
     create_autoscaling_group_resource, create_api_user_resource, create_ci_user_resource, \
     create_elasticsearch_security_group_resource, create_elasticsearch_lambda_execution_role_resource, \
     create_elasticsearch_lambda_log_group_policy_function_resource, create_elasticsearch_log_group_policy_custom_resource, \
-    create_elasticsearch_service_linked_role_resource, create_elasticsearch_resource
+    create_elasticsearch_resource
 
 from outputs import create_database_name_output, create_database_username_output, create_database_host_output, \
     create_database_port_output, create_redis_host_output, create_redis_port_output, create_default_queue_url_output, \
     create_default_queue_output, create_notifications_queue_output, create_load_balancer_domain_output, create_elasticsearch_host_output, \
-    create_elasticsearch_service_linked_role_id_output, create_docker_repository_uri_output, create_docker_cluster_name_output, \
+    create_docker_repository_uri_output, create_docker_cluster_name_output, \
     create_uploads_bucket_name_output
 
 # UUID.
@@ -226,7 +226,6 @@ elasticsearch_lambda_log_group_policy_function_resource = create_elasticsearch_l
     template, elasticsearch_log_access_policy_lambda_name_variable, elasticsearch_lambda_log_group_resource, elasticsearch_lambda_execution_role_resource)
 elasticsearch_log_group_policy_custom_resource = create_elasticsearch_log_group_policy_custom_resource(
     template, elasticsearch_lambda_log_group_policy_function_resource, elasticsearch_log_group_name_variable, elasticsearch_log_group_resource)
-elasticsearch_service_linked_role_resource = create_elasticsearch_service_linked_role_resource(template)
 elasticsearch_resource = create_elasticsearch_resource(template, elasticsearch_domain_name_variable,
                                                        elasticsearch_instance_count_parameter,
                                                        elasticsearch_instance_class_parameter,
@@ -244,7 +243,6 @@ create_default_queue_url_output(template, default_queue_resource)
 create_default_queue_output(template, default_queue_name_variable)
 create_notifications_queue_output(template, notifications_queue_name_variable)
 create_load_balancer_domain_output(template, load_balancer_resource)
-create_elasticsearch_service_linked_role_id_output(template, elasticsearch_service_linked_role_resource)
 create_elasticsearch_host_output(template, elasticsearch_resource)
 create_docker_repository_uri_output(template, docker_repository_resource)
 create_docker_cluster_name_output(template, ecs_cluster_resource)

--- a/aws/outputs.py
+++ b/aws/outputs.py
@@ -101,15 +101,6 @@ def create_load_balancer_domain_output(template, load_balancer_resource):
     )
 
 
-def create_elasticsearch_service_linked_role_id_output(template, elasticsearch_service_linked_role):
-    return template.add_output(
-        Output(
-            'ElasticsearchServiceLinkedRoleId',
-            Description='The ID of the Service Linked Role used by the Elasticsearch service',
-            Value=Ref(elasticsearch_service_linked_role)
-        )
-    )
-
 def create_elasticsearch_host_output(template, elasticsearch_resource):
     return template.add_output(
         Output(


### PR DESCRIPTION
### Summary

- The template was producing a duplicate resource error when creating the production stack
- This was linked to the elasticsearch linked role  and elasticsearch linked role ID
- As neither output was used in the stack build they were removed and the stack build completed

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
